### PR TITLE
Add example random PV IOC and GUI viewer

### DIFF
--- a/random_gui.py
+++ b/random_gui.py
@@ -1,0 +1,25 @@
+import tkinter as tk
+from epics import PV
+
+
+class RandomViewer:
+    """Simple Tkinter GUI to display the random PV."""
+
+    def __init__(self, root):
+        self.label = tk.Label(root, text='0.000', font=('Arial', 32))
+        self.label.pack(padx=30, pady=30)
+
+        # Subscribe to PV updates
+        self.pv = PV('Station_Laser:TestDevice:RandomValue',
+                     callback=self.on_update)
+
+    def on_update(self, pvname=None, value=None, **kws):
+        if value is not None:
+            self.label.config(text=f'{value:.3f}')
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    root.title("Random PV Monitor")
+    viewer = RandomViewer(root)
+    root.mainloop()

--- a/random_ioc.py
+++ b/random_ioc.py
@@ -1,0 +1,20 @@
+import asyncio
+import numpy as np
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+
+class RandomIOC(PVGroup):
+    """IOC publishing a random value PV."""
+    random_value = pvproperty(value=0.0, name='Station_Laser:TestDevice:RandomValue')
+
+    @random_value.startup
+    async def random_value(self, instance, async_lib):
+        """Update the PV with a new random number every 0.1 s."""
+        while True:
+            await self.random_value.write(float(np.random.random()))
+            await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    ioc_options, run_options = ioc_arg_parser(default_prefix='')
+    ioc = RandomIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)


### PR DESCRIPTION
## Summary
- Provide `random_ioc.py` IOC publishing `Station_Laser:TestDevice:RandomValue`
- Add `random_gui.py` displaying the PV in a Tkinter window

## Testing
- `python -m py_compile random_ioc.py random_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a68bd556988331b51b5442dd9b5842